### PR TITLE
gh-2 adjacency with line map

### DIFF
--- a/tests/test_line_map.py
+++ b/tests/test_line_map.py
@@ -6,6 +6,9 @@ class GamePiece:
   def __init__(self, name, color):
     self.name = name
     self.color = color
+  def __eq__(self, other):
+    return (hasattr(other, 'name') and self.name == other.name
+            and hasattr(other, 'color') and self.color == other.color)
 
 @pytest.fixture
 def empty_map():
@@ -47,3 +50,14 @@ def test_set_out_of_bounds(empty_map):
   # No errors
   empty_map.set(0, GamePiece('cube', 'brown'))
   empty_map.set(7, GamePiece('road', 'blue'))
+
+def test_adjacent(simple_map):
+  assert ((0, None), (2, GamePiece('pawn', 'black'))) == tuple(simple_map.adjacent(1))
+  assert ((5, GamePiece('bishop', 'white')), (7, None)) == tuple(simple_map.adjacent(6))
+  assert ((1, None), (3, None)) == tuple(simple_map.adjacent(2))
+  assert ((1, None),) == tuple(simple_map.adjacent(0))
+  assert ((6, None),) == tuple(simple_map.adjacent(7))
+  with pytest.raises(IndexError):
+    next(simple_map.adjacent(-1))
+  with pytest.raises(IndexError):
+    next(simple_map.adjacent(8))

--- a/tilemap/factory.py
+++ b/tilemap/factory.py
@@ -2,13 +2,25 @@ def create_line_map(length):
   return LineMap(length)
 
 class LineMap:
+  LEFT = -1
+  RIGHT = 1
+  DIRECTIONS = [LEFT, RIGHT]
   def __init__(self, size):
     self.tiles = [None for _ in range(size)]
-  def get(self, coor):
-    if coor < 0 or coor > len(self.tiles):
+  def exists(self, coor):
+    return coor > -1 and coor < len(self.tiles)
+  def _require_coor(self, coor):
+    if not self.exists(coor):
       raise IndexError('Coordinate {} outside tilemap bounds'.format(coor))
+  def get(self, coor):
+    self._require_coor(coor)
     return self.tiles[coor]
   def set(self, coor, content):
-    if coor < 0 or coor > len(self.tiles):
-      raise IndexError('Coordinate {} outside tilemap bounds'.format(coor))
+    self._require_coor(coor)
     self.tiles[coor] = content
+  def adjacent(self, coor):
+    self._require_coor(coor)
+    for direction in self.DIRECTIONS:
+      new_coor = coor + direction
+      if self.exists(new_coor):
+        yield (new_coor, self.tiles[new_coor])


### PR DESCRIPTION
fixes #2 
* Introduces exists method indicating whether a tile is in the line map
* Introduces adjacent method which returns a generator of coor, content pairs
* Adjacent method only includes a one-element generator if coor is at the map edge
* Introduces temporary way of handling line map directions
* Refactors some common code to check whether a tile exists and raise an exception