### PR TITLE
gh-4 Rectangle map get and set

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,7 @@
+class GamePiece:
+  def __init__(self, name, color):
+    self.name = name
+    self.color = color
+  def __eq__(self, other):
+    return (hasattr(other, 'name') and self.name == other.name
+            and hasattr(other, 'color') and self.color == other.color)

--- a/tests/test_line_map.py
+++ b/tests/test_line_map.py
@@ -1,14 +1,7 @@
 from .context import tilemap
 from tilemap import factory
+from .common import GamePiece
 import pytest
-
-class GamePiece:
-  def __init__(self, name, color):
-    self.name = name
-    self.color = color
-  def __eq__(self, other):
-    return (hasattr(other, 'name') and self.name == other.name
-            and hasattr(other, 'color') and self.color == other.color)
 
 @pytest.fixture
 def empty_map():

--- a/tests/test_rect_rect_map.py
+++ b/tests/test_rect_rect_map.py
@@ -1,0 +1,57 @@
+from .context import tilemap
+from tilemap import factory
+from .common import GamePiece
+import pytest
+
+@pytest.fixture
+def empty_map():
+  return factory.create_rectangle_map(3, 4)
+
+@pytest.fixture
+def simple_map(empty_map):
+  empty_map.set((1, 1), GamePiece('pawn', 'black'))
+  empty_map.set((2, 0), GamePiece('bishop', 'white'))
+  empty_map.set((0, 3), GamePiece('queen', 'black'))
+  return empty_map
+
+def test_get(simple_map):
+  assert None == simple_map.get((0, 0))
+  assert 'queen' == simple_map.get((0, 3)).name
+  assert None == simple_map.get((2, 2))
+  assert 'bishop' == simple_map.get((2, 0)).name
+  assert 'pawn' == simple_map.get((1, 1)).name
+
+def test_get_out_of_bounds(empty_map):
+  with pytest.raises(IndexError):
+    empty_map.get((3, 1))
+  with pytest.raises(IndexError):
+    empty_map.get((2, 4))
+  with pytest.raises(IndexError):
+    empty_map.get((-1, 0))
+  with pytest.raises(IndexError):
+    empty_map.get((1, -1))
+  empty_map.get((0, 0))
+  empty_map.get((2, 3))
+  empty_map.get((2, 0))
+  empty_map.get((0, 3))
+
+def test_set(empty_map):
+  empty_map.set((2, 0), GamePiece('meeple', 'blue'))
+  assert None == empty_map.get((0, 0))
+  assert None != empty_map.get((2, 0))
+  assert 'meeple' == empty_map.get((2, 0)).name
+
+def test_set_out_of_bounds(empty_map):
+  with pytest.raises(IndexError):
+    empty_map.set((0, -1), GamePiece('meeple', 'yellow'))
+  with pytest.raises(IndexError):
+    empty_map.set((-1, 0), GamePiece('pawn', 'white'))
+  with pytest.raises(IndexError):
+    empty_map.set((3, 1), GamePiece('bishop', 'black'))
+  with pytest.raises(IndexError):
+    empty_map.set((2, 4), GamePiece('shoe', 'silver'))
+  with pytest.raises(IndexError):
+    empty_map.set((6, 7), GamePiece('worker', 'purple'))
+  # No errors
+  empty_map.set((0, 0), GamePiece('cube', 'brown'))
+  empty_map.set((2, 3), GamePiece('road', 'blue'))

--- a/tilemap/factory.py
+++ b/tilemap/factory.py
@@ -1,5 +1,7 @@
 def create_line_map(length):
   return LineMap(length)
+def create_rectangle_map(width, height):
+  return RectRectMap(width, height)
 
 class LineMap:
   LEFT = -1
@@ -24,3 +26,28 @@ class LineMap:
       new_coor = coor + direction
       if self.exists(new_coor):
         yield (new_coor, self.tiles[new_coor])
+
+class RectRectMap:
+  def __init__(self, width, height):
+    self.width = width
+    self.height = height
+    self.cols = []
+    for _ in range(width):
+      self.cols.append([None for _ in range(height)])
+  def exists(self, coor):
+    x, y = coor
+    return x > -1 and x < self.width and y > -1 and y < self.height
+  def _require_coor(self, coor):
+    if not self.exists(coor):
+      raise IndexError('Coordinate {} outside tilemap bounds'.format(coor))
+  def _get(self, coor):
+    # internal get assumes that coor is valid
+    x, y = coor
+    return self.cols[x][y]
+  def get(self, coor):
+    self._require_coor(coor)
+    return self._get(coor)
+  def set(self, coor, content):
+    x, y = coor
+    self._require_coor(coor)
+    self.cols[x][y] = content


### PR DESCRIPTION
fixes #4 
* Introduces a rectangle map with rectangle tiles
* Refactors test GamePiece to a common file
* Rectangle maps get and set function much like line map with exceptions for out-of-bounds
* Duplicates code both in tests and in tilemaps. Future work should clean up code duplication.