### PR TITLE
gh-18 Traverse method

### DIFF
--- a/tests/test_line_map.py
+++ b/tests/test_line_map.py
@@ -65,3 +65,11 @@ def test_adjacent(simple_map):
     next(simple_map.adjacent(-1))
   with pytest.raises(IndexError):
     next(simple_map.adjacent(8))
+
+def test_tiles(simple_map):
+  actual = list(simple_map.tiles())
+  assert 8 == len(actual)
+  assert (0, None) in actual
+  assert (2, GamePiece('pawn', 'black')) in actual
+  assert (4, None) in actual
+  assert (5, GamePiece('bishop', 'white')) in actual

--- a/tests/test_rect_hex_map.py
+++ b/tests/test_rect_hex_map.py
@@ -95,3 +95,12 @@ def test_adjacent(simple_map):
     next(simple_map.adjacent((-2, 2)))
   with pytest.raises(IndexError):
     next(simple_map.adjacent((1, 3)))
+
+def test_tiles(simple_map):
+  actual = list(simple_map.tiles())
+  assert 12 == len(actual)
+  assert ((0, 0), None) in actual
+  assert ((0, 1), GamePiece('pawn', 'black')) in actual
+  assert ((-1, 3), None) in actual
+  assert ((1, 2), None) in actual
+  assert ((0, 3), GamePiece('queen', 'black')) in actual

--- a/tests/test_rect_rect_map.py
+++ b/tests/test_rect_rect_map.py
@@ -88,3 +88,12 @@ def test_adjacent(simple_map):
     next(simple_map.adjacent((-1, 2)))
   with pytest.raises(IndexError):
     next(simple_map.adjacent((2, 4)))
+
+def test_tiles(simple_map):
+  actual = list(simple_map.tiles())
+  assert 12 == len(actual)
+  assert ((0, 0), None) in actual
+  assert ((1, 1), GamePiece('pawn', 'black')) in actual
+  assert ((1, 3), None) in actual
+  assert ((2, 2), None) in actual
+  assert ((0, 3), GamePiece('queen', 'black')) in actual


### PR DESCRIPTION
fixes #18 
* Adds a method named tiles which returns all tiles of the map
* Adds a method named tile_coors which returns all tile coordinates of the map
* Supports new tiles method for all three existing maps
* Completes docstring for adjacent method
* Renames some internal data structures to not conflict with the new tiles method