### PR TITLE
gh-27 Swap two tiles

### DIFF
--- a/tests/test_line_map.py
+++ b/tests/test_line_map.py
@@ -125,3 +125,24 @@ def test_move(simple_map):
   with pytest.raises(IndexError):
     simple_map.move(-1, 3)
   assert GamePiece('meeple', 'blue') == simple_map.get(3)
+
+def test_swap(simple_map):
+  # Swap piece and empty
+  simple_map.swap(2, 4)
+  assert None == simple_map.get(2)
+  assert GamePiece('pawn', 'black') == simple_map.get(4)
+  # Swap empty and empty
+  simple_map.swap(3, 1)
+  assert None == simple_map.get(1)
+  assert None == simple_map.get(3)
+  # Swap piece and piece
+  simple_map.swap(5, 4)
+  assert GamePiece('pawn', 'black') == simple_map.get(5)
+  assert GamePiece('bishop', 'white') == simple_map.get(4)
+  # Out of bounds
+  with pytest.raises(IndexError):
+    simple_map.swap(5, 9)
+  assert GamePiece('pawn', 'black') == simple_map.get(5)
+  with pytest.raises(IndexError):
+    simple_map.swap(-1, 5)
+  assert GamePiece('pawn', 'black') == simple_map.get(5)

--- a/tests/test_rect_hex_map.py
+++ b/tests/test_rect_hex_map.py
@@ -157,3 +157,24 @@ def test_move(simple_map):
   with pytest.raises(IndexError):
     simple_map.move((-1, 0), (1, 2))
   assert GamePiece('bishop', 'white') == simple_map.get((1, 2))
+
+def test_move(simple_map):
+  # Swap piece and empty
+  simple_map.swap((0, 1), (1, 2))
+  assert None == simple_map.get((0, 1))
+  assert GamePiece('pawn', 'black') == simple_map.get((1, 2))
+  # Swap empty and empty
+  simple_map.swap((1, 1), (0, 0))
+  assert None == simple_map.get((1, 1))
+  assert None == simple_map.get((0, 0))
+  # Swap piece and piece
+  simple_map.swap((-1, 2), (1, 2))
+  assert GamePiece('pawn', 'black') == simple_map.get((-1, 2))
+  assert GamePiece('bishop', 'white') == simple_map.get((1, 2))
+  # Out of bounds
+  with pytest.raises(IndexError):
+    simple_map.swap((1, 2), (3, 2))
+  assert GamePiece('bishop', 'white') == simple_map.get((1, 2))
+  with pytest.raises(IndexError):
+    simple_map.swap((-1, 0), (1, 2))
+  assert GamePiece('bishop', 'white') == simple_map.get((1, 2))

--- a/tests/test_rect_rect_map.py
+++ b/tests/test_rect_rect_map.py
@@ -150,3 +150,24 @@ def test_move(simple_map):
   with pytest.raises(IndexError):
     simple_map.move((-1, 0), (2, 2))
   assert GamePiece('bishop', 'white') == simple_map.get((2, 2))
+
+def test_swap(simple_map):
+  # Swap piece and empty
+  simple_map.swap((2, 2), (1, 1))
+  assert None == simple_map.get((1, 1))
+  assert GamePiece('pawn', 'black') == simple_map.get((2, 2))
+  # Swap empty and empty
+  simple_map.swap((2, 1), (0, 0))
+  assert None == simple_map.get((2, 1))
+  assert None == simple_map.get((0, 0))
+  # Swap piece and piece
+  simple_map.swap((2, 0), (2, 2))
+  assert GamePiece('pawn', 'black') == simple_map.get((2, 0))
+  assert GamePiece('bishop', 'white') == simple_map.get((2, 2))
+  # Out of bounds
+  with pytest.raises(IndexError):
+    simple_map.swap((2, 2), (3, 2))
+  assert GamePiece('bishop', 'white') == simple_map.get((2, 2))
+  with pytest.raises(IndexError):
+    simple_map.swap((-1, 0), (2, 2))
+  assert GamePiece('bishop', 'white') == simple_map.get((2, 2))

--- a/tilemap/map.py
+++ b/tilemap/map.py
@@ -93,6 +93,22 @@ class Map:
     Raises:
       IndexError when either coordinate is outside the map
     """
-    self._require_coor(end_coor) # check before we set start
-    content = self.set(start_coor, None)
-    return self.set(end_coor, content)
+    self._require_coor(start_coor)
+    self._require_coor(end_coor)
+    content = self._get(start_coor)
+    self._set(start_coor, None)
+    removed_content = self._get(end_coor)
+    self._set(end_coor, content)
+    return removed_content
+  def swap(self, first_coor, second_coor):
+    """Moves the contents of the given first coordinate to the given second coordinate and vice versa.
+
+    Args:
+      first_coor (tuple): content located at this coordinate moves to second_coor
+      second_coor (tuple): content located at this coordinate moves to first_coor
+
+    Raises:
+      IndexError when either coordinate is outside the map
+    """
+    content = self.move(first_coor, second_coor)
+    self._set(first_coor, content) 


### PR DESCRIPTION
* Implements a swap method which swaps content between two tiles
* Rewrites the move method to avoid an extra _require_coor call
fixes #27 